### PR TITLE
Improve the deprecation warning

### DIFF
--- a/lib/responsive_images.js
+++ b/lib/responsive_images.js
@@ -36,7 +36,7 @@ function generateResponsiveImages() {
       return Promise.all(sizes.map(function (sizeSets) {
         return Promise.all(Object.keys(sizeSets).map(function (name) {
           var newPath = getNewPath(filePath, {prefix: name})
-          return route.set(newPath, resizeImageFn(buffer, sizeSets[name]))
+          return route.set(newPath, resizeImageFn(hexo, buffer, sizeSets[name]))
         }))
       }))
     })
@@ -54,10 +54,10 @@ function getSizesFor(filePath, rules) {
   }, [])
 }
 
-function resizeImageFn(buffer, config) {
+function resizeImageFn(hexo, buffer, config) {
   return function () {
     var img = sharp(buffer)
-    var resizeOptions = getResizeOptions(config)
+    var resizeOptions = getResizeOptions(hexo, config)
 
     return applySharpApiOptions(img, config).resize(config.width, config.height, resizeOptions).toBuffer()
   }

--- a/lib/sharp_options.js
+++ b/lib/sharp_options.js
@@ -1,59 +1,14 @@
-function deprecateWarning(message) {
-  console.log(message)
-}
-var sharpApiOptions = [
-  createOption('options', function (img, value) {
-    deprecateWarning('Pass resize options next to width and height, without the options: key')
-    return img
-  }),
-  createOption('crop', function (img, value) {
-    deprecateWarning('Use `fit: "cover"` with a `position` instead.')
-    return img
-  }),
-  createOption('embed', function (img, value) {
-    deprecateWarning('Use `fit: "container"` with a `position` instead.')
-    return img
-  }),
-  createOption('ignoreAspectRatio', function (img, value) {
-    deprecateWarning('Use `fit: "fill"` instead.')
-    return img
-  }),
-  createOption('max', function (img, value) {
-    deprecateWarning('Use `fit: "inside"` instead.')
-    return img
-  }),
-  createOption('min', function (img, value) {
-    deprecateWarning('Use `fit: "outside"` instead.')
-    return img
-  }),
-  createOption('quality', function (img, value) {
-    if (typeof value === 'undefined') {
-      return img
-    }
-
-    return img
-      .jpeg({quality: value, force: false})
-      .webp({quality: value, force: false})
-      .tiff({quality: value, force: false})
-  })
-]
-
-function createOption(name, applyFn) {
-  return {
-    configName: name,
-    applyFn: applyFn
-  }
-}
-
 function applyOptions(rawImage, options) {
-  return sharpApiOptions.reduce(function (img, option) {
-    var value = options[option.configName]
-    if (typeof value === 'undefined') {
-      return img
-    }
+  if (typeof options.quality === 'undefined') {
+    return rawImage
+  }
 
-    return option.applyFn(img, value)
-  }, rawImage)
+  var value = options.quality
+
+  return rawImage
+    .jpeg({quality: value, force: false})
+    .webp({quality: value, force: false})
+    .tiff({quality: value, force: false})
 }
 
 function pickResizeOptions(options) {
@@ -67,12 +22,19 @@ function pickResizeOptions(options) {
   }
   return result
 }
-function getResizeOptions(config) {
+
+function getResizeOptions(hexo, config) {
   // Legacy `config.options`, we accepted resize options that way
   // but now we pick them directly from the config
   var options = Object.assign(pickResizeOptions(config), config.options)
 
+  if (config.options) {
+    deprecateOption(hexo, 'options','Pass resize options next to width and height, without the options: key')
+  }
+
   if (config.embed) {
+    deprecateOption(hexo, 'embed','Use `fit: "contain"` with a `position` instead')
+
     options.fit = 'contain'
     if (typeof config.embed != 'boolean') {
       options.position = config.embed
@@ -80,18 +42,22 @@ function getResizeOptions(config) {
   }
 
   if (config.ignoreAspectRatio) {
+    deprecateOption(hexo, 'ignoreAspectRatio', 'Use `fit: "fill"` instead')
     options.fit = 'fill'
   }
 
   if (config.min) {
+    deprecateOption(hexo, 'min', 'Use `fit: "outside"` instead')
     options.fit = 'outside'
   }
 
   if (config.max) {
+    deprecateOption(hexo, 'max', 'Use `fit: "inside"` instead')
     options.fit = 'inside'
   }
 
   if (config.crop) {
+    deprecateOption(hexo, 'crop', 'Use `fit: "cover"` with a `position` instead')
     options.fit = 'cover'
     if (typeof config.crop != 'boolean') {
       options.position = config.crop
@@ -99,6 +65,10 @@ function getResizeOptions(config) {
   }
 
   return options
+}
+
+function deprecateOption(hexo, name, message) {
+  hexo.log.warn('[Responsive images plugin] Deprecated option "' + name + '" found in the config. ' + message)
 }
 
 exports.applyOptions = applyOptions


### PR DESCRIPTION
Make use of `hexo.log.warn` instead. 
Instruct what should be replaced.