### PR TITLE
chore(deps-dev): bump hexo from 4.0.0 to 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,8 @@
   "devDependencies": {
     "@ava/babel": "^1.0.0",
     "ava": "^3.0",
-    "hexo": "^4.0.0",
+    "hexo": "^5.1.1",
     "hexo-test-utils": "^0.4.1"
-  },
-  "resolutions": {
-    "hexo/swig-templates/optimist/minimist": "0.2.1"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
Current security alert is caused by swig, switching to hexo 5 would drop dependency on swig.